### PR TITLE
EF 9 db warning fix

### DIFF
--- a/Blogifier.sln
+++ b/Blogifier.sln
@@ -35,6 +35,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Blogifier.Themes.Standard",
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "themes", "themes", "{4155E512-4F91-48D3-823A-45B7C71125A0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Blogifier.UI.Tests", "tests\Blogifier.UI.Tests\Blogifier.UI.Tests.csproj", "{666E5A94-758C-4432-84C6-0FF83EE30003}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -105,6 +107,18 @@ Global
 		{7784DF02-6BCF-40A9-B327-C1F173975714}.Release|x64.Build.0 = Release|Any CPU
 		{7784DF02-6BCF-40A9-B327-C1F173975714}.Release|x86.ActiveCfg = Release|Any CPU
 		{7784DF02-6BCF-40A9-B327-C1F173975714}.Release|x86.Build.0 = Release|Any CPU
+		{666E5A94-758C-4432-84C6-0FF83EE30003}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{666E5A94-758C-4432-84C6-0FF83EE30003}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{666E5A94-758C-4432-84C6-0FF83EE30003}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{666E5A94-758C-4432-84C6-0FF83EE30003}.Debug|x64.Build.0 = Debug|Any CPU
+		{666E5A94-758C-4432-84C6-0FF83EE30003}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{666E5A94-758C-4432-84C6-0FF83EE30003}.Debug|x86.Build.0 = Debug|Any CPU
+		{666E5A94-758C-4432-84C6-0FF83EE30003}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{666E5A94-758C-4432-84C6-0FF83EE30003}.Release|Any CPU.Build.0 = Release|Any CPU
+		{666E5A94-758C-4432-84C6-0FF83EE30003}.Release|x64.ActiveCfg = Release|Any CPU
+		{666E5A94-758C-4432-84C6-0FF83EE30003}.Release|x64.Build.0 = Release|Any CPU
+		{666E5A94-758C-4432-84C6-0FF83EE30003}.Release|x86.ActiveCfg = Release|Any CPU
+		{666E5A94-758C-4432-84C6-0FF83EE30003}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -112,6 +126,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{27EB38D0-E275-4033-93B6-3ED6E6B7B442} = {8DDBCDEC-BFD8-4737-93BD-5259C3AE9CAE}
 		{7784DF02-6BCF-40A9-B327-C1F173975714} = {4155E512-4F91-48D3-823A-45B7C71125A0}
+		{666E5A94-758C-4432-84C6-0FF83EE30003} = {8DDBCDEC-BFD8-4737-93BD-5259C3AE9CAE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8AA706E7-D820-4892-9F60-FCEEDC51FF5E}

--- a/src/Blogifier/Data/AppDbContextExtensions.cs
+++ b/src/Blogifier/Data/AppDbContextExtensions.cs
@@ -31,6 +31,8 @@ public static class AppDbContextExtensions
       services.AddDbContext<AppDbContext, SqliteDbContext>(o =>
       {
         o.UseSqlite(sonnectionStringBuilder.ToString());
+        o.ConfigureWarnings(w =>
+          w.Ignore(RelationalEventId.NonTransactionalMigrationOperationWarning));
         o.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
       });
     }
@@ -39,6 +41,8 @@ public static class AppDbContextExtensions
       services.AddDbContext<AppDbContext, SqlServerDbContext>(o =>
       {
         o.UseSqlServer(connectionString);
+        o.ConfigureWarnings(w =>
+          w.Ignore(RelationalEventId.NonTransactionalMigrationOperationWarning));
         o.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
 
       });
@@ -49,6 +53,8 @@ public static class AppDbContextExtensions
       services.AddDbContext<AppDbContext, MySqlDbContext>(o =>
       {
         o.UseMySql(connectionString, version);
+        o.ConfigureWarnings(w =>
+          w.Ignore(RelationalEventId.NonTransactionalMigrationOperationWarning));
         o.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
       });
     }
@@ -57,6 +63,8 @@ public static class AppDbContextExtensions
       services.AddDbContext<AppDbContext, PostgresDbContext>(o =>
       {
         o.UseNpgsql(connectionString);
+        o.ConfigureWarnings(w =>
+          w.Ignore(RelationalEventId.NonTransactionalMigrationOperationWarning));
         o.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
       });
     }

--- a/src/Blogifier/Data/AppDbContextExtensions.cs
+++ b/src/Blogifier/Data/AppDbContextExtensions.cs
@@ -9,6 +9,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 
 namespace Blogifier.Data;
 
@@ -27,20 +28,36 @@ public static class AppDbContextExtensions
       var dataSourcePath = Path.Combine(environment.ContentRootPath, sonnectionStringBuilder.DataSource);
       var dataSourceDirectory = Path.GetDirectoryName(dataSourcePath);
       if (!string.IsNullOrEmpty(dataSourceDirectory) && !Directory.Exists(dataSourceDirectory)) Directory.CreateDirectory(dataSourceDirectory);
-      services.AddDbContext<AppDbContext, SqliteDbContext>(o => o.UseSqlite(sonnectionStringBuilder.ToString()));
+      services.AddDbContext<AppDbContext, SqliteDbContext>(o =>
+      {
+        o.UseSqlite(sonnectionStringBuilder.ToString());
+        o.ConfigureWarnings(w => w.Ignore(RelationalEventId.MigrationsUserTransactionWarning));
+      });
     }
     else if ("SqlServer".Equals(provider, StringComparison.OrdinalIgnoreCase))
     {
-      services.AddDbContext<AppDbContext, SqlServerDbContext>(o => o.UseSqlServer(connectionString));
+      services.AddDbContext<AppDbContext, SqlServerDbContext>(o =>
+      {
+        o.UseSqlServer(connectionString);
+        o.ConfigureWarnings(w => w.Ignore(RelationalEventId.MigrationsUserTransactionWarning));
+      });
     }
     else if ("MySql".Equals(provider, StringComparison.OrdinalIgnoreCase))
     {
       var version = ServerVersion.AutoDetect(connectionString);
-      services.AddDbContext<AppDbContext, MySqlDbContext>(o => o.UseMySql(connectionString, version));
+      services.AddDbContext<AppDbContext, MySqlDbContext>(o =>
+      {
+        o.UseMySql(connectionString, version);
+        o.ConfigureWarnings(w => w.Ignore(RelationalEventId.MigrationsUserTransactionWarning));
+      });
     }
     else if ("Postgres".Equals(provider, StringComparison.OrdinalIgnoreCase))
     {
-      services.AddDbContext<AppDbContext, PostgresDbContext>(o => o.UseNpgsql(connectionString));
+      services.AddDbContext<AppDbContext, PostgresDbContext>(o =>
+      {
+        o.UseNpgsql(connectionString);
+        o.ConfigureWarnings(w => w.Ignore(RelationalEventId.MigrationsUserTransactionWarning));
+      });
     }
     else
     {

--- a/src/Blogifier/Data/AppDbContextExtensions.cs
+++ b/src/Blogifier/Data/AppDbContextExtensions.cs
@@ -31,7 +31,7 @@ public static class AppDbContextExtensions
       services.AddDbContext<AppDbContext, SqliteDbContext>(o =>
       {
         o.UseSqlite(sonnectionStringBuilder.ToString());
-        o.ConfigureWarnings(w => w.Ignore(RelationalEventId.MigrationsUserTransactionWarning));
+        o.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
       });
     }
     else if ("SqlServer".Equals(provider, StringComparison.OrdinalIgnoreCase))
@@ -39,7 +39,8 @@ public static class AppDbContextExtensions
       services.AddDbContext<AppDbContext, SqlServerDbContext>(o =>
       {
         o.UseSqlServer(connectionString);
-        o.ConfigureWarnings(w => w.Ignore(RelationalEventId.MigrationsUserTransactionWarning));
+        o.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
+
       });
     }
     else if ("MySql".Equals(provider, StringComparison.OrdinalIgnoreCase))
@@ -48,7 +49,7 @@ public static class AppDbContextExtensions
       services.AddDbContext<AppDbContext, MySqlDbContext>(o =>
       {
         o.UseMySql(connectionString, version);
-        o.ConfigureWarnings(w => w.Ignore(RelationalEventId.MigrationsUserTransactionWarning));
+        o.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
       });
     }
     else if ("Postgres".Equals(provider, StringComparison.OrdinalIgnoreCase))
@@ -56,7 +57,7 @@ public static class AppDbContextExtensions
       services.AddDbContext<AppDbContext, PostgresDbContext>(o =>
       {
         o.UseNpgsql(connectionString);
-        o.ConfigureWarnings(w => w.Ignore(RelationalEventId.MigrationsUserTransactionWarning));
+        o.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
       });
     }
     else

--- a/tests/Blogifier.UI.Tests/Blogifier.UI.Tests.csproj
+++ b/tests/Blogifier.UI.Tests/Blogifier.UI.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
+        <PackageReference Include="Microsoft.Playwright.NUnit" Version="1.27.1"/>
+        <PackageReference Include="NUnit" Version="3.14.0"/>
+        <PackageReference Include="NUnit.Analyzers" Version="3.9.0"/>
+        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Microsoft.Playwright.NUnit"/>
+        <Using Include="NUnit.Framework"/>
+        <Using Include="System.Text.RegularExpressions"/>
+        <Using Include="System.Threading.Tasks"/>
+    </ItemGroup>
+
+</Project>

--- a/tests/Blogifier.UI.Tests/UnitTest1.cs
+++ b/tests/Blogifier.UI.Tests/UnitTest1.cs
@@ -1,0 +1,27 @@
+namespace Blogifier.UI.Tests;
+
+[Parallelizable(ParallelScope.Self)]
+[TestFixture]
+public class Tests : PageTest
+{
+  [Test]
+  public async Task HomepageHasPlaywrightInTitleAndGetStartedLinkLinkingtoTheIntroPage()
+  {
+    await Page.GotoAsync("https://playwright.dev");
+
+    // Expect a title "to contain" a substring.
+    await Expect(Page).ToHaveTitleAsync(new Regex("Playwright"));
+
+    // create a locator
+    var getStarted = Page.Locator("text=Get Started");
+
+    // Expect an attribute "to be strictly equal" to the value.
+    await Expect(getStarted).ToHaveAttributeAsync("href", "/docs/intro");
+
+    // Click the get started link.
+    await getStarted.ClickAsync();
+
+    // Expects the URL to contain intro.
+    await Expect(Page).ToHaveURLAsync(new Regex(".*intro"));
+  }
+}


### PR DESCRIPTION
Suppress EF PendingModelChangesWarning and prevent that an InvalidOprationException is thrown. See https://learn.microsoft.com/en-us/ef/core/what-is-new/ef-core-9.0/breaking-changes.